### PR TITLE
fix: externe klanttaak 1.0.1

### DIFF
--- a/backend/externe-klanttaak/plugin.properties
+++ b/backend/externe-klanttaak/plugin.properties
@@ -1,3 +1,18 @@
+#
+# Copyright 2025 Ritense BV, the Netherlands.
+#
+# Licensed under EUPL, Version 1.2 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 pluginGroupId=com.ritense.valtimoplugins
 pluginArtifactId=externe-klanttaak
-pluginVersion=1.0.0
+pluginVersion=1.0.1

--- a/backend/externe-klanttaak/src/main/kotlin/com/ritense/externeklanttaak/version/v1x1x0/CreateExterneKlanttaakActionV1x1x0.kt
+++ b/backend/externe-klanttaak/src/main/kotlin/com/ritense/externeklanttaak/version/v1x1x0/CreateExterneKlanttaakActionV1x1x0.kt
@@ -57,6 +57,7 @@ import org.camunda.bpm.engine.delegate.DelegateTask
 import java.net.URI
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
@@ -127,17 +128,17 @@ class CreateExterneKlanttaakActionV1x1x0(
             koppeling = pluginActionConfig.koppelingRegistratie?.let {
                 TaakKoppeling(
                     registratie = it,
-                    uuid = requireNotNull(pluginActionConfig.koppelingUuid) {
+                    value = requireNotNull(pluginActionConfig.koppelingUuid) {
                         "Property [portaalformulierValue] is required when [koppelingRegistratie] is ${pluginActionConfig.koppelingRegistratie}"
                     },
                 )
             },
             verloopdatum = stringAsInstantOrNull(pluginActionConfig.verloopdatum)
                 ?.let {
-                    LocalDate.ofInstant(it, ZoneOffset.UTC)
+                    LocalDateTime.ofInstant(it, ZoneOffset.UTC)
                 }
                 ?: delegateTask.dueDate?.let {
-                    LocalDate.ofInstant(it.toInstant(), ZoneOffset.UTC)
+                    LocalDateTime.ofInstant(it.toInstant(), ZoneOffset.UTC)
                 },
             verwerkerTaakId = delegateTask.id
         )

--- a/backend/externe-klanttaak/src/main/kotlin/com/ritense/externeklanttaak/version/v1x1x0/ExterneKlanttaakV1x1x0.kt
+++ b/backend/externe-klanttaak/src/main/kotlin/com/ritense/externeklanttaak/version/v1x1x0/ExterneKlanttaakV1x1x0.kt
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
 import com.ritense.externeklanttaak.domain.IExterneKlanttaak
 import com.ritense.externeklanttaak.version.v1x1x0.ExterneKlanttaakV1x1x0.TaakStatus.AFGEROND
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class ExterneKlanttaakV1x1x0(
@@ -35,7 +35,7 @@ data class ExterneKlanttaakV1x1x0(
     val portaalformulier: PortaalFormulier? = null,
     val identificatie: TaakIdentificatie,
     val koppeling: TaakKoppeling? = null,
-    val verloopdatum: LocalDate? = null,
+    val verloopdatum: LocalDateTime? = null,
     val eigenaar: String? = DEFAULT_EIGENAAR,
 ) : IExterneKlanttaak {
     override fun canBeHandled(): Boolean = status == AFGEROND
@@ -87,7 +87,7 @@ data class ExterneKlanttaakV1x1x0(
 
     data class TaakKoppeling(
         val registratie: TaakKoppelingRegistratie,
-        val uuid: String?,
+        val value: String?,
     )
 
     enum class TaakKoppelingRegistratie(

--- a/backend/externe-klanttaak/src/test/kotlin/com/ritense/externeklanttaak/ExterneKlanttaakPluginIT.kt
+++ b/backend/externe-klanttaak/src/test/kotlin/com/ritense/externeklanttaak/ExterneKlanttaakPluginIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -550,7 +550,13 @@ class ExterneKlanttaakPluginIT : BaseIntegrationTest() {
                         }
                     }
 
-                    "/zaakinformatieobjecten" -> getLinkDocumentResponse()
+                    "/zaakinformatieobjecten" -> {
+                        when (request.method) {
+                            "POST" -> getLinkDocumentResponse()
+                            "GET" -> getZaakDocumentenResponse()
+                            else -> MockResponse().setResponseCode(405)
+                        }
+                    }
 
                     else -> MockResponse().setResponseCode(404)
                 }
@@ -583,6 +589,24 @@ class ExterneKlanttaakPluginIT : BaseIntegrationTest() {
         return mockJsonResponse(body)
     }
 
+    private fun getZaakDocumentenResponse(): MockResponse {
+
+        val body =
+            """
+                [
+                    {
+                    "url": "http://localhost/${UUID.randomUUID()}",
+                    "uuid": "${UUID.randomUUID()}",
+                    "informatieobject": "http://localhost/${UUID.randomUUID()}",
+                    "zaak": "${server.url("/")}zaak",
+                    "aardRelatieWeergave": "something",
+                    "registratiedatum": "2024-11-20T14:13:22Z"
+                    }
+                ]
+            """.trimIndent()
+        return mockJsonResponse(body)
+    }
+
     private fun getLinkDocumentResponse(): MockResponse {
         val body =
             """
@@ -591,6 +615,7 @@ class ExterneKlanttaakPluginIT : BaseIntegrationTest() {
                 "uuid": "${UUID.randomUUID()}",
                 "informatieobject": "http://localhost/${UUID.randomUUID()}",
                 "zaak": "${server.url("/")}zaak",
+                "aardRelatieWeergave": "something",
                 "registratiedatum": "2024-11-20T14:13:22Z"
                 }
             """.trimIndent()
@@ -664,7 +689,7 @@ class ExterneKlanttaakPluginIT : BaseIntegrationTest() {
                             "type": "bsn",
                             "value": "999990755"
                         },
-                        "verloopdatum": "2024-12-24",
+                        "verloopdatum": "2024-12-23T23:00",
                         "eigenaar": "GZAC",
                         "verwerker_taak_id": "$verwerkerTaakId"
                     },
@@ -709,7 +734,7 @@ class ExterneKlanttaakPluginIT : BaseIntegrationTest() {
                             "type": "bsn",
                             "value": "999990755"
                         },
-                        "verloopdatum": "2024-12-24",
+                        "verloopdatum": "2024-12-23T23:00",
                         "eigenaar": "GZAC",
                         "verwerker_taak_id": "$verwerkerTaakId"
                     },

--- a/backend/externe-klanttaak/src/test/kotlin/com/ritense/externeklanttaak/ExterneKlanttaakServiceTest.kt
+++ b/backend/externe-klanttaak/src/test/kotlin/com/ritense/externeklanttaak/ExterneKlanttaakServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/backend/externe-klanttaak/src/test/kotlin/com/ritense/externeklanttaak/TestHelper.kt
+++ b/backend/externe-klanttaak/src/test/kotlin/com/ritense/externeklanttaak/TestHelper.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.ritense.externeklanttaak
 
 import com.fasterxml.jackson.databind.JsonNode
@@ -25,7 +41,7 @@ object TestHelper {
                     "type" : "bsn",
                     "value" : "999990755"
                   },
-                  "verloopdatum" : "2024-12-24",
+                  "verloopdatum" : "2024-12-23T23:00:00",
                   "eigenaar" : "GZAC",
                   "verwerker_taak_id" : "fake-task-id"
             }
@@ -43,7 +59,7 @@ object TestHelper {
                     "type" : "bsn",
                     "value" : "999990755"
                   },
-                  "verloopdatum" : "2024-12-24",
+                  "verloopdatum" : "2024-12-23T23:00:00",
                   "eigenaar" : "GZAC",
                   "verwerker_taak_id" : "fake-task-id"
            }
@@ -61,7 +77,7 @@ object TestHelper {
                     "type" : "bsn",
                     "value" : "999990755"
                   },
-                  "verloopdatum" : "2024-12-24",
+                  "verloopdatum" : "2024-12-23T23:00:00",
                   "eigenaar" : "GZAC",
                   "verwerker_taak_id" : "fake-task-id"
            }
@@ -85,7 +101,7 @@ object TestHelper {
                         "type" : "bsn",
                         "value" : "999990755"
                       },
-                      "verloopdatum" : "2024-12-24",
+                      "verloopdatum" : "2024-12-23T23:00:00",
                       "eigenaar" : "GZAC",
                       "verwerker_taak_id" : "fake-task-id"
                     },
@@ -111,7 +127,7 @@ object TestHelper {
                         "type" : "bsn",
                         "value" : "999990755"
                       },
-                      "verloopdatum" : "2024-12-24",
+                      "verloopdatum" : "2024-12-23T23:00:00",
                       "eigenaar" : "GZAC",
                       "verwerker_taak_id" : "fake-task-id"
                     },
@@ -137,7 +153,7 @@ object TestHelper {
                         "type" : "bsn",
                         "value" : "999990755"
                       },
-                      "verloopdatum" : "2024-12-24",
+                      "verloopdatum" : "2024-12-23T23:00:00",
                       "eigenaar" : "GZAC",
                       "verwerker_taak_id" : "fake-task-id"
                     },

--- a/backend/externe-klanttaak/src/test/kotlin/com/ritense/externeklanttaak/impl/ExterneKlanttaakV1x1x0Test.kt
+++ b/backend/externe-klanttaak/src/test/kotlin/com/ritense/externeklanttaak/impl/ExterneKlanttaakV1x1x0Test.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.ritense.externeklanttaak.impl
 
 import com.ritense.externeklanttaak.domain.IExterneKlanttaak
@@ -33,6 +49,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.net.URI
+import java.time.LocalDateTime
 import java.util.Date
 import java.util.UUID
 import kotlin.test.Test
@@ -75,7 +92,7 @@ class ExterneKlanttaakV1x1x0Test {
                 .withProcessBusinessKey(processBusinessKey)
         val delegateTask =
             DelegateTaskFake()
-                .withId("task-id")
+                .withId(UUID.randomUUID().toString())
                 .withName("Do something!")
                 .withExecution(delegateExecutionFake)
         val zaakUrl = URI.create("https://example.com/zaak-url")
@@ -121,6 +138,7 @@ class ExterneKlanttaakV1x1x0Test {
         assertEquals(delegateTask.name, klanttaak.titel)
         assertEquals(TYPE_BSN, klanttaak.identificatie.type)
         assertEquals("999990755", klanttaak.identificatie.value)
+        assertEquals(LocalDateTime.parse("2024-10-28T23:00:00"), klanttaak.verloopdatum)
     }
 
     @Test
@@ -134,7 +152,7 @@ class ExterneKlanttaakV1x1x0Test {
                 .withProcessInstanceId(processInstanceId)
         val delegateTask =
             DelegateTaskFake()
-                .withId("task-id")
+                .withId(UUID.randomUUID().toString())
                 .withName("Do something!")
                 .withExecution(delegateExecutionFake)
 
@@ -191,7 +209,7 @@ class ExterneKlanttaakV1x1x0Test {
                 .withProcessBusinessKey(processBusinessKey)
         val delegateTask =
             DelegateTaskFake()
-                .withId("task-id")
+                .withId(UUID.randomUUID().toString())
                 .withName("Do something!")
                 .withExecution(delegateExecutionFake)
                 .apply {


### PR DESCRIPTION
* fixed koppeling value property having incorrect name and not matching the Externe Klantaak 1.1.x specification. `uuid` -> `value`
* fixed type of `verloopdatum` property not matching the Externe Klantaak 1.1.x specification. `LocalDate` -> `LocalDateTime`