### PR TITLE
fix: do not throw on unknown verwerker taak id

### DIFF
--- a/backend/externe-klanttaak/plugin.properties
+++ b/backend/externe-klanttaak/plugin.properties
@@ -15,4 +15,4 @@
 #
 pluginGroupId=com.ritense.valtimoplugins
 pluginArtifactId=externe-klanttaak
-pluginVersion=1.0.1
+pluginVersion=1.0.2

--- a/backend/externe-klanttaak/src/main/kotlin/com/ritense/externeklanttaak/listener/ExterneKlanttaakEventListener.kt
+++ b/backend/externe-klanttaak/src/main/kotlin/com/ritense/externeklanttaak/listener/ExterneKlanttaakEventListener.kt
@@ -34,6 +34,7 @@ import com.ritense.processdocument.domain.impl.CamundaProcessInstanceId
 import com.ritense.processdocument.service.ProcessDocumentService
 import com.ritense.valtimo.camunda.domain.CamundaTask
 import com.ritense.valtimo.contract.json.MapperSingleton
+import com.ritense.valtimo.security.exceptions.TaskNotFoundException
 import com.ritense.valtimo.service.CamundaProcessService
 import com.ritense.valtimo.service.CamundaTaskService
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -82,7 +83,7 @@ open class ExterneKlanttaakEventListener(
                 }
                 ?: run {
                     logger.info {
-                        "Skipping Event: No ExterneKlantaakPlugin configuration found for handling this object"
+                        "Skipping Event: No Externe Klantaak Plugin configuration found for handling this object"
                     }
                     return@handle
                 }
@@ -119,11 +120,11 @@ open class ExterneKlanttaakEventListener(
         val camundaTask: CamundaTask =
             try {
                 taskService.findTaskById(klanttaak.verwerkerTaakId)
-            } catch (ex: Exception) {
-                throw RuntimeException(
-                    "Task with id ${klanttaak.verwerkerTaakId} not found. Can not handle this Externe Klanttaak.",
-                    ex
-                )
+            } catch (ex: TaskNotFoundException) {
+                logger.info {
+                    "Skipping Event: Could not find Camunda task with id ${klanttaak.verwerkerTaakId}. Externe Klanttaak doesn't belong to this application."
+                }
+                return
             }
 
         handleResourceAsExterneKlanttaak(


### PR DESCRIPTION
* fixed exceptions being thrown when attempting to handle a task that doesn't belong to the current gzac instance - should log attempt and continue