### PR TITLE
Plugin: Rotterdam Oracle EBS - support 'numeric' like keys in grootboek enum

### DIFF
--- a/frontend/projects/valtimo-plugins/rotterdam-oracle-ebs/package.json
+++ b/frontend/projects/valtimo-plugins/rotterdam-oracle-ebs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@valtimo-plugins/rotterdam-oracle-ebs",
   "license": "EUPL-1.2",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "peerDependencies": {
     "@angular/common": "^17.2.2",
     "@angular/core": "^17.2.2"

--- a/frontend/projects/valtimo-plugins/rotterdam-oracle-ebs/plugin.properties
+++ b/frontend/projects/valtimo-plugins/rotterdam-oracle-ebs/plugin.properties
@@ -1,2 +1,2 @@
 pluginArtifactId=rotterdam-oracle-ebs
-pluginVersion=1.4.1
+pluginVersion=1.4.2

--- a/frontend/projects/valtimo-plugins/rotterdam-oracle-ebs/src/lib/components/journaalpost-opvoeren/journaalpost-opvoeren.component.ts
+++ b/frontend/projects/valtimo-plugins/rotterdam-oracle-ebs/src/lib/components/journaalpost-opvoeren/journaalpost-opvoeren.component.ts
@@ -229,7 +229,9 @@ export class JournaalpostOpvoerenComponent implements FunctionConfigurationCompo
         if (this.isValueResolverPrefix(value)) {
             return value;
         } else {
-            return this.enumSvc.getEnumValue(Grootboek, value);
+            // If a numeric-like key (e.g., "100") is provided, treat it as "_100"
+            const normalizedKey = (/^\d/.test(value) && !value.startsWith('_')) ? `_${value}` : value;
+            return this.enumSvc.getEnumValue(Grootboek, normalizedKey);
         }
     }
 
@@ -237,7 +239,8 @@ export class JournaalpostOpvoerenComponent implements FunctionConfigurationCompo
         if (this.isValueResolverPrefix(value)) {
             return value;
         } else {
-            return this.enumSvc.getEnumKey(Grootboek, value);
+            // If a numeric-like key, strip _ prefix from the key
+            return this.enumSvc.getEnumKey(Grootboek, value).replace(/^_/, '');
         }
     }
 


### PR DESCRIPTION
support 'numeric' like keys in grootboek enum to return key without _ prefix and parse value input without _ to match key with _ prefix